### PR TITLE
Improved Documentation (Auto readme.pod)

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -3,7 +3,30 @@ use strict;
 use warnings;
 use Module::Build;
 
-my $build = Module::Build->new(
+#This part (creating a subclass) helps generating
+# a github-friendly readme.pod file alongside with
+# the traditional readme file with no markdown.
+my $class = Module::Build->subclass(
+    class => 'My::Builder',
+    code => q{
+        sub ACTION_docs {
+            use Pod::Readme;
+            use Pod::Select;
+
+            my $self = shift;
+
+            podselect({ -output => 'README.pod' },
+                'lib/Exporter/Declare.pm');
+
+            my $parser = Pod::Readme->new();
+            $parser->parse_from_file('README.pod', 'README');
+
+            return $self->SUPER::ACTION_docs;
+        }
+    }
+);
+
+my $build = $class->new(
     module_name => 'Exporter::Declare',
     license     => 'perl',
     dist_author => 'Chad Granum <exodist7@gmail.com>',

--- a/Build.PL
+++ b/Build.PL
@@ -38,16 +38,10 @@ my $build = $class->new(
         'aliased'       => 0,
         'Meta::Builder' => '0.003',
     },
-    configure_requires => {
-        'Pod::Readme' => 0,
-        'Pod::Select' => 0,
-    },
     build_requires => {
         'Test::Simple'    => 0.88,
         'Fennec::Lite'    => '0.004',
         'Test::Exception' => '0.29',
-        'Pod::Readme' => 0,
-        'Pod::Select' => 0,
     },
     meta_merge => {
         resources => {

--- a/Build.PL
+++ b/Build.PL
@@ -38,10 +38,16 @@ my $build = $class->new(
         'aliased'       => 0,
         'Meta::Builder' => '0.003',
     },
+    configure_requires => {
+        'Pod::Readme' => 0,
+        'Pod::Select' => 0,
+    },
     build_requires => {
         'Test::Simple'    => 0.88,
         'Fennec::Lite'    => '0.004',
         'Test::Exception' => '0.29',
+        'Pod::Readme' => 0,
+        'Pod::Select' => 0,
     },
     meta_merge => {
         resources => {

--- a/README
+++ b/README
@@ -117,18 +117,18 @@ SYNOPSIS
 IMPORT INTERFACE
     Importing from a package that uses Exporter::Declare will be familiar to
     anyone who has imported from modules before. Arguments are all assumed
-    to be export names, unless prefixed with "-" or ":" In which case they
+    to be export names, unless prefixed with `-' or `:' In which case they
     may be a tag or an option. Exports without a sigil are assumed to be
     code exports, variable exports must be listed with their sigil.
 
-    Items prefixed with the "!" symbol are forcfully excluded, regardless of
-    any listed item that may normally include them. Tags can also be
+    Items prefixed with the `!' symbol are forcefully excluded, regardless
+    of any listed item that may normally include them. Tags can also be
     excluded, this will effectively exclude everything in the tag.
 
     Tags are simply lists of exports, the exporting class may define any
     number of tags. Exporter::Declare also has the concept of options, they
     have the same syntax as tags. Options may be boolean or argument based.
-    Boolean options are actually 3 value, undef, false "!", or true.
+    Boolean options are actually 3 value, undef, false `!', or true.
     Argument based options will grab the next value in the arguments list as
     their own, regardless of what type of value it is.
 
@@ -143,15 +143,15 @@ IMPORT INTERFACE
   SELECTING ITEMS TO IMPORT
     Exports can be subs, or package variables (scalar, hash, array). For
     subs simply ask for the sub by name, you may optionally prefix the subs
-    name with the sub sigil "&". For variables list the variable name along
-    with its sigil "$, %, or @".
+    name with the sub sigil `&'. For variables list the variable name along
+    with its sigil `$, %, or @'.
 
         use Some::Exporter qw/ somesub $somescalar %somehash @somearray /;
 
   TAGS
     Every exporter automatically has the following 3 tags, in addition they
     may define any number of custom tags. Tags can be specified by their
-    name prefixed by either "-" or ":".
+    name prefixed by either `-' or `:'.
 
     -all
         This tag may be used to import everything the exporter provides.
@@ -162,10 +162,10 @@ IMPORT INTERFACE
 
     -alias
         Every package has an alias that it can export. This is the last
-        segmant of the packages namespace. IE "My::Long::Package::Name::Foo"
-        could export the "Foo()" function. These alias functionis simply
+        segment of the packages namespace. IE `My::Long::Package::Name::Foo'
+        could export the `Foo()' function. These alias functions simply
         return the full package name as a string, in this case
-        'My::Long::Package::Name::Foo'. This is similar to aliased.
+        `'My::Long::Package::Name::Foo''. This is similar to aliased.
 
         The -alias tag is a shortcut so that you do not need to think about
         what the alias name would be when adding it to the import arguments.
@@ -178,18 +178,18 @@ IMPORT INTERFACE
     You can prefix, suffix, or completely rename the items you import.
     Whenever an item is followed by a hash in the import list, that hash
     will be used for configuration. Configuration items always start with a
-    dash "-".
+    dash `-'.
 
     The 3 available configuration options that effect import names are
-    "-prefix", "-suffix", and "-as". If "-as" is seen it will be used as is.
+    `-prefix', `-suffix', and `-as'. If `-as' is seen it will be used as is.
     If prefix or suffix are seen they will be attached to the original name
     (unless -as is present in which case they are ignored).
 
         use Some::Exporter subA => { -as => 'DoThing' },
                            subB => { -prefix => 'my_', -suffix => '_ok' };
 
-    The example above will import "subA()" under the name "DoThing()". It
-    will also import "subB()" under the name "my_subB_ok()".
+    The example above will import `subA()' under the name `DoThing()'. It
+    will also import `subB()' under the name `my_subB_ok()'.
 
     You may als specify a prefix and/or suffix for tags. The following
     example will import all the default exports with 'my_' prefixed to each
@@ -239,8 +239,8 @@ IMPORT INTERFACE
 
     The example above will work fine, all the arguments will make it into
     the generator. The only valid reason for this to work is that you may
-    provide arguments such as "-prefix" to a tag that brings in generator(),
-    while also desiring to give arguments to generator() independantly.
+    provide arguments such as `-prefix' to a tag that brings in generator(),
+    while also desiring to give arguments to generator() independently.
 
 PRIMARY EXPORT API
     With the exception of import(), all the following work equally well as

--- a/README.pod
+++ b/README.pod
@@ -1,0 +1,401 @@
+=head1 NAME
+
+Exporter::Declare - Exporting done right
+
+=head1 DESCRIPTION
+
+Exporter::Declare is a meta-driven exporting tool. Exporter::Declare tries to
+adopt all the good features of other exporting tools, while throwing away
+horrible interfaces. Exporter::Declare also provides hooks that allow you to add
+options and arguments for import. Finally, Exporter::Declare's meta-driven
+system allows for top-notch introspection.
+
+=head1 FEATURES
+
+=over 4
+
+=item Declarative exporting (like L<Moose> for exporting)
+
+=item Meta-driven for introspection
+
+=item Customizable import() method
+
+=item Export groups (tags)
+
+=item Export generators for subs and variables
+
+=item Clear and concise OO API
+
+=item Exports are blessed, allowing for more introspection
+
+=item Import syntax based off of L<Sub::Exporter>
+
+=item Packages export aliases
+
+=back
+
+=head1 SYNOPSIS
+
+=head2 EXPORTER
+
+    package Some::Exporter;
+    use Exporter::Declare;
+
+    default_exports qw/ do_the_thing /;
+    exports qw/ subA subB $SCALAR @ARRAY %HASH /;
+
+    # Create a couple tags (import lists)
+    export_tag subs => qw/ subA subB do_the_thing /;
+    export_tag vars => qw/ $SCALAR @ARRAY %HASH /;
+
+    # These are simple boolean options, pass '-optionA' to enable it.
+    import_options   qw/ optionA optionB /;
+
+    # These are options which slurp in the next argument as their value, pass
+    # '-optionC' => 'foo' to give it a value.
+    import_arguments qw/ optionC optionD /;
+
+    export anon_export => sub { ... };
+    export '@anon_var' => [...];
+
+    default_export a_default => sub { 'default!' }
+
+    our $X = "x";
+    default_export '$X';
+
+    my $iterator = 'a';
+    gen_export unique_class_id => sub {
+        my $current = $iterator++;
+        return sub { $current };
+    };
+
+    gen_default_export '$my_letter' => sub {
+        my $letter = $iterator++;
+        return \$letter;
+    };
+
+    # You can create a function to mangle the arguments before they are
+    # parsed into a Exporter::Declare::Spec object.
+    sub alter_import_args {
+       my ($class, $args) = @_;
+
+       # fiddle with args before importing routines are called
+       @$args = grep { !/^skip_/ } @$args
+    }
+
+    # There is no need to fiddle with import() or do any wrapping.
+    # the $specs data structure means you generally do not need to parse
+    # arguments yourself (but you can if you want using alter_import_args())
+
+    # Change the spec object before export occurs
+    sub before_import {
+        my $class = shift;
+        my ( $importer, $specs ) = @_;
+
+        if ($specs->config->{optionA}) {
+            # Modify $spec attributes accordingly
+        }
+    }
+
+    # Use spec object after export occurs
+    sub after_import {
+        my $class = shift;
+        my ( $importer, $specs ) = @_;
+
+        do_option_a() if $specs->config->{optionA};
+
+        do_option_c( $specs->config->{optionC} )
+            if $specs->config->{optionC};
+
+        print "-subs tag was used\n"
+            if $specs->config->{subs};
+
+        print "exported 'subA'\n"
+            if $specs->exports->{subA};
+    }
+
+    ...
+
+=head2 IMPORTER
+
+    package Some::Importer;
+    use Some::Exporter qw/ subA $SCALAR !%HASH /,
+                        -default => { -prefix => 'my_' },
+                        qw/ -optionA !-optionB /,
+                        subB => { -as => 'sub_b' };
+
+    subA();
+    print $SCALAR;
+    sub_b();
+    my_do_the_thing();
+
+    ...
+
+=head1 IMPORT INTERFACE
+
+Importing from a package that uses Exporter::Declare will be familiar to anyone
+who has imported from modules before. Arguments are all assumed to be export
+names, unless prefixed with C<-> or C<:> In which case they may be a tag or an
+option. Exports without a sigil are assumed to be code exports, variable
+exports must be listed with their sigil.
+
+Items prefixed with the C<!> symbol are forcefully excluded, regardless of any
+listed item that may normally include them. Tags can also be excluded, this
+will effectively exclude everything in the tag.
+
+Tags are simply lists of exports, the exporting class may define any number of
+tags. Exporter::Declare also has the concept of options, they have the same
+syntax as tags. Options may be boolean or argument based. Boolean options are
+actually 3 value, undef, false C<!>, or true. Argument based options will grab
+the next value in the arguments list as their own, regardless of what type of
+value it is.
+
+When you use the module, or call import(), all the arguments are transformed
+into an L<Exporter::Declare::Specs> object. Arguments are parsed for you into a
+list of imports, and a configuration hash in which tags/options are keys. Tags
+are listed in the config hash as true, false, or undef depending on if they
+were included, negated, or unlisted. Boolean options will be treated in the
+same way as tags. Options that take arguments will have the argument as their
+value.
+
+=head2 SELECTING ITEMS TO IMPORT
+
+Exports can be subs, or package variables (scalar, hash, array). For subs
+simply ask for the sub by name, you may optionally prefix the subs name with
+the sub sigil C<&>. For variables list the variable name along with its sigil
+C<$, %, or @>.
+
+    use Some::Exporter qw/ somesub $somescalar %somehash @somearray /;
+
+=head2 TAGS
+
+Every exporter automatically has the following 3 tags, in addition they may
+define any number of custom tags. Tags can be specified by their name prefixed
+by either C<-> or C<:>.
+
+=over 4
+
+=item -all
+
+This tag may be used to import everything the exporter provides.
+
+=item -default
+
+This tag is used to import the default items exported. This will be used when
+no argument is provided to import.
+
+=item -alias
+
+Every package has an alias that it can export. This is the last segment of the
+packages namespace. IE C<My::Long::Package::Name::Foo> could export the C<Foo()>
+function. These alias functions simply return the full package name as a
+string, in this case C<'My::Long::Package::Name::Foo'>. This is similar to
+L<aliased>.
+
+The -alias tag is a shortcut so that you do not need to think about what the
+alias name would be when adding it to the import arguments.
+
+    use My::Long::Package::Name::Foo -alias;
+
+    my $foo = Foo()->new(...);
+
+=back
+
+=head2 RENAMING IMPORTED ITEMS
+
+You can prefix, suffix, or completely rename the items you import. Whenever an
+item is followed by a hash in the import list, that hash will be used for
+configuration. Configuration items always start with a dash C<->.
+
+The 3 available configuration options that effect import names are C<-prefix>,
+C<-suffix>, and C<-as>. If C<-as> is seen it will be used as is. If prefix or
+suffix are seen they will be attached to the original name (unless -as is
+present in which case they are ignored).
+
+    use Some::Exporter subA => { -as => 'DoThing' },
+                       subB => { -prefix => 'my_', -suffix => '_ok' };
+
+The example above will import C<subA()> under the name C<DoThing()>. It will
+also import C<subB()> under the name C<my_subB_ok()>.
+
+You may als specify a prefix and/or suffix for tags. The following example will
+import all the default exports with 'my_' prefixed to each name.
+
+    use Some::Exporter -default => { -prefix => 'my_' };
+
+=head2 OPTIONS
+
+Some exporters will recognise options. Options look just like tags, and are
+specified the same way. What options do, and how they effect things is
+exporter-dependant.
+
+    use Some::Exporter qw/ -optionA -optionB /;
+
+=head2 ARGUMENTS
+
+Some options require an argument. These options are just like other
+tags/options except that the next item in the argument list is slurped in as
+the option value.
+
+    use Some::Exporter -ArgOption    => 'Value, not an export',
+                       -ArgTakesHash => { ... };
+
+Once again available options are exporter specific.
+
+=head2 PROVIDING ARGUMENTS FOR GENERATED ITEMS
+
+Some items are generated at import time. These items may accept arguments.
+There are 3 ways to provide arguments, and they may all be mixed (though that
+is not recommended).
+
+As a hash
+
+    use Some::Exporter generated => { key => 'val', ... };
+
+As an array
+
+    use Some::Exporter generated => [ 'Arg1', 'Arg2', ... ];
+
+As an array in a config hash
+
+    use Some::Exporter generated => { -as => 'my_gen', -args => [ 'arg1', ... ]};
+
+You can use all three at once, but this is really a bad idea, documented for completeness:
+
+    use Some::Exporter generated => { -as => 'my_gen, key => 'value', -args => [ 'arg1', 'arg2' ]}
+                       generated => [ 'arg3', 'arg4' ];
+
+The example above will work fine, all the arguments will make it into the
+generator. The only valid reason for this to work is that you may provide
+arguments such as C<-prefix> to a tag that brings in generator(), while also
+desiring to give arguments to generator() independently.
+
+=head1 PRIMARY EXPORT API
+
+With the exception of import(), all the following work equally well as
+functions or class methods.
+
+=over 4
+
+=item import( @args )
+
+The import() class method. This turns the @args list into an
+L<Exporter::Declare::Specs> object.
+
+=item exports( @add_items )
+
+Add items to be exported.
+
+=item @list = exports()
+
+Retrieve list of exports.
+
+=item default_exports( @add_items )
+
+Add items to be exported, and add them to the -default tag.
+
+=item @list = default_exports()
+
+List of exports in the -default tag
+
+=item import_options(@add_items)
+
+Specify boolean options that should be accepted at import time.
+
+=item import_arguments(@add_items)
+
+Specify options that should be accepted at import that take arguments.
+
+=item export_tag( $name, @add_items );
+
+Define an export tag, or add items to an existing tag.
+
+=back
+
+=head1 EXTENDED EXPORT API
+
+These all work fine in function or method form, however the syntax sugar will
+only work in function form.
+
+=over 4
+
+=item reexport( $package )
+
+Make this exporter inherit all the exports and tags of $package. Works for
+Exporter::Declare or Exporter.pm based exporters. Re-Exporting of
+L<Sub::Exporter> based classes is not currently supported.
+
+=item export_to( $package, @args )
+
+Export to the specified class.
+
+=item export( $name )
+
+=item export( $name, $ref )
+
+export is a keyword that lets you export any 1 item at a time. The item can be
+exported by name, or name + ref. When a ref is provided, the export is created,
+but there is no corresponding variable/sub in the packages namespace.
+
+=item default_export( $name )
+
+=item default_export( $name, $ref )
+
+=item gen_export( $name )
+
+=item gen_export( $name, $ref )
+
+=item gen_default_export( $name )
+
+=item gen_default_export( $name, $ref )
+
+These all act just like export(), except that they add subrefs as generators,
+and/or add exports to the -default tag.
+
+=back
+
+=head1 MAGIC
+
+Please use L<Exporter::Declare::Magic> directly from now on.
+
+=head2 DEPRECATED USAGE OF MAGIC
+
+    use Exporter::Declare '-magic';
+
+This adds L<Devel::Declare> magic to several functions. It also allows you to
+easily create or use parsers on your own exports. See
+L<Exporter::Declare::Magic> for more details.
+
+You can also provide import arguments to L<Devel::Declare::Magic>
+
+    # Arguments to -magic must be in an arrayref, not a hashref.
+    use Exporter::Declare -magic => [ '-default', '!export', -prefix => 'magic_' ];
+
+=head1 INTERNAL API
+
+Exporter/Declare.pm does not have much logic to speak of. Rather
+Exporter::Declare is sugar on top of class meta data stored in
+L<Exporter::Declare::Meta> objects. Arguments are parsed via
+L<Exporter::Declare::Specs>, and also turned into objects. Even exports are
+blessed references to the exported item itself, and handle the injection on
+their own (See L<Exporter::Declare::Export>).
+
+=head1 META CLASS
+
+All exporters have a meta class, the only way to get the meta object is to call
+the exporter_meta() method on the class/object that is an exporter. Any class
+that uses Exporter::Declare gets this method, and a meta-object.
+
+=head1 AUTHORS
+
+Chad Granum L<exodist7@gmail.com>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2010 Chad Granum
+
+Exporter-Declare is free software; Standard perl licence.
+
+Exporter-Declare is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the license for more details.


### PR DESCRIPTION
Here's another try: Now I have edited Build.PL file so that it generates github-friendly Readme.pod file as well as traditional Readme file. Generated Readme files are committed.
I have referred to the post at http://blogs.perl.org/users/michal_wojciechowski/2011/11/github-friendly-readme-files-with-extutils-makemaker-and-module-build.html upon making the changes.
Hope you find this PR useful. (This contribution is part of CPAN-PR challenge)
